### PR TITLE
fix: make reset-version portable across BSD and GNU sed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,11 @@
 .PHONY: deps pre-commit test reset-version
 
+UNAME_S := $(shell uname -s)
+ifeq ($(UNAME_S),Darwin)
+	SED_INPLACE := sed -i ''
+else
+	SED_INPLACE := sed -i
+endif
 
 deps:
 	@echo "=== Install dependencies ==="
@@ -18,7 +24,7 @@ test: deps pre-commit
 reset-version:
 	@echo "=== Resetting version numbers to 0.0.1 ==="
 	# Only update the version field in pyproject.toml
-	sed -i -E 's/^(version = ")([0-9]+\.[0-9]+\.[0-9]+)(")/\1 0.0.1\3/' pyproject.toml
+	$(SED_INPLACE) -E 's/^(version = ")([0-9]+\.[0-9]+\.[0-9]+)(")/\10.0.1\3/' pyproject.toml
 	# Update version numbers in .py files
-	find . -type f -name '*.py' -exec sed -i -E 's/[0-9]+\.[0-9]+\.[0-9]+/0.0.1/g' {} +
+	find . -type f -name '*.py' -exec $(SED_INPLACE) -E 's/[0-9]+\.[0-9]+\.[0-9]+/0.0.1/g' {} +
 	@echo "--- Version numbers reset to 0.0.1 ---"


### PR DESCRIPTION
## Summary
- `make reset-version` was broken on macOS: BSD `sed -i` requires an explicit backup-suffix argument, so `-i -E` consumed `-E` as that suffix instead of enabling extended regex, leaving `\1`/`\3` undefined ("`\1 not defined in the RE`").
- Also fixes a stray space in the replacement that would have produced `version = " 0.0.1"` instead of `version = "0.0.1"`.
- Detects OS via `uname -s` and uses `sed -i ''` on Darwin, plain `sed -i` elsewhere, so the target now works on both BSD (macOS) and GNU (Linux) sed.

## Test plan
- [x] Ran `make reset-version` on macOS — confirms `pyproject.toml`, `src/tidy_python/__init__.py`, and the test comment are correctly rewritten to `0.0.1`
- [x] Reverted the test-run version bump, keeping only the Makefile fix